### PR TITLE
Remove unnecessary `not`

### DIFF
--- a/curl-name.md
+++ b/curl-name.md
@@ -27,7 +27,7 @@ programming language. That curl still [exists](http://www.curl.com).
 
 Several libcurl bindings for various programming languages use the term "curl"
 or "CURL" in part or completely to describe their bindings, so sometimes
-you'll find users talk about curl but not target neither the command line tool
+you'll find users talk about curl but target neither the command line tool
 nor the library that is made by this project.
 
 ### As a verb


### PR DESCRIPTION
Option would be to switch to `either/or` instead of `neither/nor`