### PR TITLE
libcurl-threading.md: Refer to the thread safety webpage

### DIFF
--- a/libcurl-threading.md
+++ b/libcurl-threading.md
@@ -1,3 +1,7 @@
 ## libcurl multi-threading
 
-TBD
+libcurl is thread safe but has no internal thread synchronization. You may have
+to provide your own locking or change options to properly use libcurl threaded.
+Exactly what is required depends on how libcurl was built. Please refer to the
+[libcurl thread safety](https://curl.haxx.se/libcurl/c/threadsafe.html)
+webpage, which contains the latest information.


### PR DESCRIPTION
Rather than duplicate the thread safety documentation in this book
provide a brief description and then refer to the thread safety webpage.

I think this is a safer move since the thread safety nuances are subject
to change, and the reader should always have the latest information.

Bug: https://curl.haxx.se/mail/lib-2017-04/0042.html
Reported-by: Vitaliy T