### PR TITLE
Fix typo

### DIFF
--- a/http-https.md
+++ b/http-https.md
@@ -4,7 +4,7 @@ HTTPS is in effect Secure HTTP. The "secure" part means that the TCP transport
 layer is enhanced to provide authentication, privacy (encryption) and data
 integrity by the use of TLS.
 
-See the [Using TLS](usincurl-tls.md) section for in-depth details on how to
+See the [Using TLS](usingcurl-tls.md) section for in-depth details on how to
 modify and tweak the TLS details in a HTTPS transfer.
 
 


### PR DESCRIPTION
There was a typo in a linked page name.