### PR TITLE
added installation instruction for Arch Linux

### DIFF
--- a/get-curl-linux.md
+++ b/get-curl-linux.md
@@ -55,7 +55,12 @@ In order to install command-line tool:
 
 ## Arch Linux
 
-TBD
+curl is located in the core repository of Arch Linux. This means it should be 
+installed automatically if you follow the normal installation procedure.
+
+If curl is not installed, Arch Linux uses `pacman` to install packages:
+    
+    pacman -S curl
 
 ## Other distros
 


### PR DESCRIPTION
Hello Daniel, 

I found that there is no installation instruction for Arch Linux, but the step to install curl on Arch Linux is quite easy, so I added the following instruction. 
Unless you have something else planned for this section, I think this can be added to the book.
Tell me what you think!

Thank you.

God bless!
Wayne Lai.