### PR TITLE
fix wording

### DIFF
--- a/cmdline-passwords.md
+++ b/cmdline-passwords.md
@@ -1,6 +1,6 @@
 ## Passwords and snooping
 
-Passwords are tricky and sensitive. Leaking a password can make someone else
+Passwords are tricky and sensitive. Leaking a password can make someone other
 than you access the resources and the data otherwise protected.
 
 curl offers several ways to receive passwords from the user and then

--- a/cmdline-passwords.md
+++ b/cmdline-passwords.md
@@ -36,7 +36,7 @@ example, it makes curl use HTTP Basic authentication and that is completely
 insecure.
 
 There are several ways to avoid this, and the key is, of course, then to avoid
-protocols or authentication schemes that sends credentials in the plain over
+protocols or authentication schemes that sends credentials in plain text over
 the network. Easiest is perhaps to make sure you use encrypted versions of
 protocols. Use HTTPS instead of HTTP, use FTPS instead of FTP and so on.
 

--- a/cmdline-progressmeter.md
+++ b/cmdline-progressmeter.md
@@ -7,7 +7,7 @@ how long it has been going on and how long it thinks it might be left until
 completion.
 
 The progress meter is inhibited if curl deems that there is output going to
-the terminal, as then would the progress meter interfere with that output and
+the terminal, as the progress meter would interfere with that output and
 just mess up what gets displayed. A user can also forcibly switch off the
 progress meter with the `-s / --silent` option, which tells curl to hush.
 


### PR DESCRIPTION
Three wording changes.

I think `in the plain` is correct but I added this change because the first read-through had me double checking. Open to interpretation.