### PR TITLE
Update curl-name.md

### DIFF
--- a/curl-name.md
+++ b/curl-name.md
@@ -2,10 +2,8 @@
 
 Naming things is hard.
 
-The tool was about uploading and downloading data specified with a URL. It
-would show the data (by default). The user would "see" the URL perhaps and
-"see" then spelled with the single letter 'c'. It was also a client-side
-program, a URL client. So 'c' for Client and URL: **cURL**.
+The tool was about uploading and downloading data specified with a URL. It was a client-side
+program (the 'c'), a URL client, and would show the data (by default). So 'c' for Client and URL: **cURL**.
 
 Nothing more was needed so the name was selected and we never looked back
 again.
@@ -29,15 +27,15 @@ help.
 
 ### Confusions and mixups
 
-Soon after curl was first created another "curl" appeared that makes a
+Soon after our curl was created another "curl" appeared that created a
 programming language. That curl still [exists](http://www.curl.com).
 
 Several libcurl bindings for various programming languages use the term "curl"
-or "CURL" in part or completely to describe their bindings, so sometimes
-you will find users talking about curl but targeting neither the command-line tool
+or "CURL" in part or completely to describe their bindings. Sometimes
+you will find users talking about curl but referring to neither the command-line tool
 nor the library that is made by this project.
 
-### As a verb
+### Used as a verb
 
-'to curl something' is sometimes used as a reference to use a non-browser tool
+'To curl something' is sometimes used as a reference to use a non-browser tool
 to download a file or resource from a URL.


### PR DESCRIPTION
The user would "see" the URL perhaps and
"see" then spell it with the single letter 'c'.     -- Removed because it confuses the reader (well, me anyway). I tried to mimic the concept I believe was being communicated in a simpler way.