### PR TITLE
[etiquette]: "the guys who" => "those who"

### DIFF
--- a/curl-etiquette.md
+++ b/curl-etiquette.md
@@ -104,7 +104,7 @@ Many people mail questions to the list, people spend some of their time and
 make an effort in providing good answers to these questions.
 
 If you are the one who asks, please consider responding once more in case one
-of the hints was what solved your problems. The guys who write answers feel
+of the hints was what solved your problems. Those who write answers feel
 good to know that they provided a good answer and that you fixed the
 problem. Far too often, the person who asked the question is never heard of
 again, and we never get to know if he/she is gone because the problem was


### PR DESCRIPTION
Remove unnecessary gender-slanting in discussion of mailing list etiquette.

I realize that "guys" **can** be used as a generic non-gendered term. As a "guy" myself, I use it that way all the time, though usually as a form of direct address ("hey, guys").

This is not one of those generic uses.

In fact, it sort of leaps off the page/screen at you when, towards the end of a long section on etiquette that's fairly neutral with its terminology, suddenly users of the mailing list are described as "[t]he guys who write answers".

It's unnecessary phrasing, and while the cURL project's [code of conduct](https://ec.haxx.se/opensource-coc.html) stops short of addressing issues of _bias_ (focusing mostly on the more damaging issue of harassment), I feel it reflects poorly on cURL.