### PR TITLE
tls-sslkeylogfile: Fix Wireshark preferences protocol name s/SSL/TLS/

### DIFF
--- a/tls-sslkeylogfile.md
+++ b/tls-sslkeylogfile.md
@@ -15,8 +15,8 @@ that it can decrypt them:
 choice before you start the browser or curl
 
 2. Setting the same file name path in the Master-secret field in Wireshark. Go
-to Preferences->Protocols->SSL and edit the path as shown in the screenshot
-below.
+to Preferences->Protocols->TLS (SSL in older versions) and edit the path as
+shown in the screenshot below.
 
 ![set the ssl key file name](wireshark-ssl-master-secret.png)
 


### PR DESCRIPTION
Wireshark switched to TLS as the protocol name. The user has to go to
Preferences->Protocols->TLS to set the master secrets file location.

Closes #xxxx