### PR TITLE
cmdline-globbing.md: Warn URLs with [] {} must be quoted

### DIFF
--- a/cmdline-globbing.md
+++ b/cmdline-globbing.md
@@ -10,6 +10,11 @@ normally cannot be part of a legal URL (except for numerical IPv6 addresses
 but curl handles them fine anyway). If the globbing gets in your way, disable
 it with `-g, --globoff`.
 
+When using [] or {} sequences when invoked from a command line prompt, you
+probably have to put the full URL within double quotes to avoid the shell from
+interfering with it. This also goes for other characters treated special, like
+for example '&', '?' and '*'.
+
 While most transfer related functionality in curl is provided by the libcurl
 library, the URL globbing feature is not!
 
@@ -19,24 +24,24 @@ You can ask for a numerical range with [N-M] syntax, where N is the start
 index and it goes up to and including M. For example, you can ask for 100
 images one by one that are named numerically:
 
-    curl -O http://example.com/[1-100].png
+    curl -O "http://example.com/[1-100].png"
 
 and it can even do the ranges with zero prefixes, like if the number is
 three digits all the time:
 
-    curl -O http://example.com/[001-100].png
+    curl -O "http://example.com/[001-100].png"
 
 Or maybe you only want even-numbered images so you tell curl a step counter
 too. This example range goes from 0 to 100 with an increment of 2:
 
-    curl -O http://example.com/[0-100:2].png
+    curl -O "http://example.com/[0-100:2].png"
 
 ### Alphabetical ranges
 
 curl can also do alphabetical ranges, like when a site has sections named a
 to z:
 
-    curl -O http://example.com/section[a-z].html
+    curl -O "http://example.com/section[a-z].html"
 
 ### A list
 
@@ -44,7 +49,7 @@ Sometimes the parts do not follow such an easy pattern, and then you can
 instead give the full list yourself but then within the curly braces instead
 of the brackets used for the ranges:
 
-    curl -O http://example.com/{one,two,three,alpha,beta}.html
+    curl -O "http://example.com/{one,two,three,alpha,beta}.html"
 
 ### Combinations
 
@@ -52,17 +57,17 @@ You can use several globs in the same URL which then will make curl iterate
 over those, too. To download the images of Ben, Alice and Frank, in both the
 resolutions 100 * 100 and 1000 * 1000, a command line could look like:
 
-    curl -O http://example.com/{Ben,Alice,Frank}-{100x100,1000x1000}.jpg
+    curl -O "http://example.com/{Ben,Alice,Frank}-{100x100,1000x1000}.jpg"
 
 Or download all the images of a chess board, indexed by two coordinates ranged
 0 to 7:
 
-    curl -O http://example.com/chess-[0-7]x[0-7].jpg
+    curl -O "http://example.com/chess-[0-7]x[0-7].jpg"
 
 And you can, of course, mix ranges and series. Get a week's worth of logs for
 both the web server and the mail server:
 
-    curl -O http://example.com/{web,mail}-log[0-6].txt
+    curl -O "http://example.com/{web,mail}-log[0-6].txt"
 
 ### Output variables for globbing
 
@@ -81,8 +86,8 @@ starts with 1 for the first glob and ends with the last glob.
 
 Save the main pages of two different sites:
 
-    curl http://{one,two}.example.com -o "file_#1.txt"
+    curl "http://{one,two}.example.com" -o "file_#1.txt"
 
 Save the outputs from a command line with two globs in a subdirectory;
 
-    curl http://{site,host}.host[1-5].example.com -o "subdir/#1_#2"
+    curl "http://{site,host}.host[1-5].example.com" -o "subdir/#1_#2"


### PR DESCRIPTION
- Warn that URLs containing [] and {} should be quoted since they may be
  shell metacharacters. (The warning paragraph is a c&p from curl.1.)

- Quote the globbing example URLs that contain those characters.

Bug: https://github.com/curl/curl/issues/5388
Reported-by: John Simpson

Closes #xxxx