### PR TITLE
ftp-advanced.md: Quote globbing characters

### DIFF
--- a/ftp-advanced.md
+++ b/ftp-advanced.md
@@ -42,7 +42,7 @@ or to use the local file name as the remote name:
 curl also supports [globbing](cmdline-globbing.md) in the -T argument so you
 can opt to easily upload a range or a series of files:
 
-    curl -T image[1-99].jpg ftp://ftp.example.com/upload/
+    curl -T 'image[1-99].jpg' ftp://ftp.example.com/upload/
 
 or
 


### PR DESCRIPTION
The unquoted command

    curl -T image[1-99].jpg ftp://ftp.example.com/upload/

risks getting expanded by the shell before it is passed to curl, which would be equivalent to

    curl -T image1.jpg image2.jpg [...] image99.jpg ftp://ftp.example.com/upload/

which would lead to curl treating the strings `image2.jpg` to `image99.jpg` to be treated as URLs.

I added quotes to pass the globbing characters to curl.