### PR TITLE
usingcurl-proxies.md: correct the proxy port

### DIFF
--- a/usingcurl-proxies.md
+++ b/usingcurl-proxies.md
@@ -87,7 +87,7 @@ using the scheme prefix. See the [SOCKS](#socks) section below.
 An HTTP proxy is a proxy that the client speaks HTTP with to get the transfer
 done. curl will, by default, assume that a host you point out with `-x` or
 `--proxy` is an HTTP proxy, and unless you also specify a port number it will
-default to port 3128 (and the reason for that particular port number is purely
+default to port 1080 (and the reason for that particular port number is purely
 historical).
 
 If you want to request the example.com web page using a proxy on 192.168.0.1
@@ -103,7 +103,7 @@ If you enable verbose mode with `-v` when talking to a proxy, you will see
 that curl connects to the proxy instead of the remote server, and you will see
 that it uses a slightly different request line.
 
-## HTTPS and proxy
+## HTTPS with HTTP proxy
 
 HTTPS was designed to allow and provide secure and safe end-to-end privacy
 from the client to the server (and back). In order to provide that when
@@ -250,6 +250,8 @@ reside.
 
 One solution for that is to use HTTPS to the proxy, which then establishes a
 secure and encrypted connection that is safe from easy surveillance.
+
+When a HTTPS proxy is specified, the default port will be 443.
 
 ## Proxy environment variables
 


### PR DESCRIPTION
... and mention the default for HTTPS proxies.

Reported-by: Patrik Lundin
Fixes #129