### PR TITLE
word inconsistent with topic

### DIFF
--- a/http/response.md
+++ b/http/response.md
@@ -54,7 +54,7 @@ numeric range and you can use `--write-out` to extract that code as well.
 An HTTP 1.1 server can decide to respond with a "chunked" encoded response, a
 feature that was not present in HTTP 1.0.
 
-When sending a chunked response, there's no Content-Length: for the response
+When receiving a chunked response, there's no Content-Length: for the response
 to indicate its size. Instead, there's a `Transfer-Encoding: chunked` header
 that tells curl there's chunked data coming and then in the response body, the
 data comes in a series of "chunks". Every individual chunk starts with the


### PR DESCRIPTION
this paragraph would be improved by changing 'sending' to 'receiving' as the topic is from the point of view of curl as the client and processing what has been received (i.e. the response header section and its the chunked body). thank you for considering my recommendation.