### PR TITLE
superfluous statement and unclear sentence

### DIFF
--- a/http/post.md
+++ b/http/post.md
@@ -109,9 +109,9 @@ entire string by prefixing it with an equals sign (that will not get sent):
 ### Convert that to a GET
 
 A little convenience feature that could be suitable to mention in this context
-(even though it is not for POSTing), is the `-G` or `--get` option, which
+is the `-G` or `--get` option, which
 takes all data you have specified with the different `-d` variants and appends
-that data on the right end of the URL separated with a '?' and then makes curl
+that data to the command-line URL e.g. ```http://example.com``` separated with a '?' and then makes curl
 send a GET instead.
 
 This option makes it easy to switch between POSTing and GETing a form, for

--- a/http/post.md
+++ b/http/post.md
@@ -111,7 +111,7 @@ entire string by prefixing it with an equals sign (that will not get sent):
 A little convenience feature that could be suitable to mention in this context
 is the `-G` or `--get` option, which
 takes all data you have specified with the different `-d` variants and appends
-that data to the command-line URL e.g. ```http://example.com``` separated with a '?' and then makes curl
+that data to the inputted URL e.g. ```http://example.com``` separated with a '?' and then makes curl
 send a GET instead.
 
 This option makes it easy to switch between POSTing and GETing a form, for


### PR DESCRIPTION
this paragraph can be improved by 1) omitting the statement that POST is not GET (this is fundamentally true insofar as the text of the method is one or the other and it is stated at the end of the paragraph) and 2) clarifying that the convenience comes from reusing the field information from a POST so that the luser doesn't have to manually add it end of the url on the command line. i have proposed my wording thus to accomplish these improvements. thank you for considering my suggestions.