### PR TITLE
typo

### DIFF
--- a/http/altsvc.md
+++ b/http/altsvc.md
@@ -2,7 +2,7 @@
 
 [RFC 7838](https://www.rfc-editor.org/rfc/rfc7838.txt) defines a HTTP header
 which lets a server tell a client that there is one or more *alternatives* for
-that server at "another place" with the use of the `Alt-Svc:` response ehader.
+that server at "another place" with the use of the `Alt-Svc:` response header.
 
 The *alternatives* the server suggests can include a server running on another
 port on the same host, on another completely different host name and it can

--- a/http/altsvc.md
+++ b/http/altsvc.md
@@ -22,7 +22,7 @@ new or updated `Alt-Svc:` headers, curl will store those in the cache at exit.
 ## The alt-svc cache
 
 The alt-svc cache is very similar to a cookie jar. It is a text based file
-that stores one alternative per line and each entry also has an expiry time so
+that stores one alternative per line and each entry also has an expiry time
 for which duration that particular alternative is valid.
 
 ## HTTPS only

--- a/http/browserlike.md
+++ b/http/browserlike.md
@@ -9,7 +9,7 @@ Here are some tricks and advice on how to proceed when doing this.
 
 ## Figure out what the browser does
 
-This is really a necessary first step. Second-guessing what it does risk having
+This is really a necessary first step. Second-guessing what it does risks having
 you chase down the wrong problem rat-hole. The scientific approach to this
 problem pretty much requires that you first understand what the browser does.
 

--- a/http/browserlike.md
+++ b/http/browserlike.md
@@ -25,7 +25,7 @@ what HTTP operations it performs.
 The [Copy as curl](usingcurl-copyas.md) section describes how you can record a
 browser's request and easily convert that to a curl command line.
 
-Those copied curl command lines are often not Good enough though since they
+Those copied curl command lines are often not good enough though since they
 tend to copy *exactly* that request, while you probably want to be a bad bit
 more dynamic so that you can reproduce the same operation and not just resend
 the verbatim request.

--- a/http/browserlike.md
+++ b/http/browserlike.md
@@ -77,7 +77,7 @@ tag anyway, you could do something like this first:
 
     curl -c cookies https://example.com/ -o loginform
 
-You would often need a HTML parser or some script language to extract the id
+You would often need a HTML parser or some scripting language to extract the id
 field from there and then you can proceed and login as mentioned above, but
 with the added cookie loading (I'm splitting the line into two lines to make
 it more readable):


### PR DESCRIPTION
the clarity of this sentence can be improved by changing 'ehader', heretofore nonexistent, to the known and clearly fitting word 'header'. thank you for considering my recommendation.