### PR TITLE
Update options.md

### DIFF
--- a/libcurl/options.md
+++ b/libcurl/options.md
@@ -46,7 +46,7 @@ Enforce a long:
 Enforce a curl_off_t:
 
     curl_off_t no_larger_than = 0x50000;
-    curl_easy_setopt(handle, CURLOPT_MAXFILE_LARGE, no_larger_than);
+    curl_easy_setopt(handle, CURLOPT_MAXFILESIZE_LARGE, no_larger_than);
 
 ## Get handle options
 


### PR DESCRIPTION
```
 error: ‘CURLOPT_MAXFILE_LARGE’ was not declared in this scope; did you mean ‘CURLOPT_MAXFILESIZE_LARGE’?
   31 |   curl_err = curl_easy_setopt(curl, CURLOPT_MAXFILE_LARGE, no_larger_than);
      |                                     ^~~~~~~~~~~~~~~~~~~~~
make: *** [Makefile:95: build/x86_64-linux-gnu/init.o] Error 1
```

