### PR TITLE
cmdline/urls/scheme.md: mention the support schemes

### DIFF
--- a/cmdline/urls/scheme.md
+++ b/cmdline/urls/scheme.md
@@ -61,3 +61,12 @@ While this gets data from a HTTP server:
 
 You can modify the default protocol to something other than HTTP with the
 `--proto-default` option.
+
+## Supported schemes
+
+curl supports or can be made to support (if built so) the following transfer
+schemes and protocols:
+
+DICT, FILE, FTP, FTPS, GOPHER, GOPHERS, HTTP, HTTPS, IMAP, IMAPS, LDAP, LDAPS,
+MQTT, POP3, POP3S, RTMP, RTMPS, RTSP, SCP, SFTP, SMB, SBMS, SMTP, SMTPS,
+TELNET and TFTP

--- a/usingcurl.md
+++ b/usingcurl.md
@@ -5,15 +5,6 @@ something about the basic command lines. You use command-line options and you
 pass on URLs to work with.
 
 In this chapter, we are going to dive deeper into a variety of different
-concepts of what curl can do and how to tell curl to use these features. You
-should consider all these features as different tools that are here to help
-you do your file transfer tasks as conveniently as possible.
-
-## Supported protocols
-
-curl supports or can be made to support (if built so) the following transfer
-protocols.
-
-DICT, FILE, FTP, FTPS, GOPHER, GOPHERS, HTTP, HTTPS, IMAP, IMAPS, LDAP, LDAPS,
-MQTT, POP3, POP3S, RTMP, RTMPS, RTSP, SCP, SFTP, SMB, SBMS, SMTP, SMTPS,
-TELNET and TFTP
+concepts of what the curl tool can do and how to tell curl to use these
+features. You should consider all these features as different tools that are
+here to help you do your file transfer tasks as conveniently as possible.


### PR DESCRIPTION
... instad of having "supported protocols" in the using curl intro, as
it felt a bit wrongly placed there.