### PR TITLE
runtime: remove hypen from run-time

### DIFF
--- a/badwords.txt
+++ b/badwords.txt
@@ -1,6 +1,6 @@
 back-end
 e-mail
-runtime
+run-time
 set-up
 toolchain
 tool-chain

--- a/http/redirects.md
+++ b/http/redirects.md
@@ -129,9 +129,9 @@ of these kinds of redirects.
 
 ## JavaScript redirects
 
-The modern web is full of JavaScript and as you know, JavaScript is a
-language and a full run-time that allows code to execute in the browser when
-visiting websites.
+The modern web is full of JavaScript and as you know, JavaScript is a language
+and a full runtime that allows code to execute in the browser when visiting
+websites.
 
 JavaScript also provides means for it to instruct the browser to move on to
 another site—a redirect, if you will.

--- a/http/response.md
+++ b/http/response.md
@@ -78,9 +78,9 @@ sizes to users.
 Responses over HTTP can be sent in compressed format. This is most commonly
 done by the server when it includes a `Content-Encoding: gzip` in the response
 as a hint to the client. Compressed responses make a lot of sense when either
-static resources are sent (that were compressed previously) or even in
-run-time when there is more CPU power available than bandwidth. Sending a much
-smaller amount of data is often preferred.
+static resources are sent (that were compressed previously) or even in runtime
+when there is more CPU power available than bandwidth. Sending a much smaller
+amount of data is often preferred.
 
 You can ask curl to both ask for compressed content *and* automatically and
 transparently uncompress gzipped data when receiving content encoded gzip (or

--- a/libcurl/api.md
+++ b/libcurl/api.md
@@ -68,7 +68,7 @@ This number is also available as three separate defines:
 
 These defines are, of course, only suitable to figure out the version number
 built *just now* and they will not help you figuring out which libcurl version
-that is used at run-time three years from now.
+that is used at runtime three years from now.
 
 ### Which libcurl version runs
 


### PR DESCRIPTION
In spirit with email and backend, use runtime instead of run-time

See also this [graph](https://books.google.com/ngrams/graph?content=runtime%2Crun-time&year_start=1980&year_end=2019&corpus=26&smoothing=3&direct_url=t1%3B%2Cruntime%3B%2Cc0%3B.t1%3B%2Crun%20-%20time%3B%2Cc0#t1%3B%2Cruntime%3B%2Cc0%3B.t1%3B%2Crun%20-%20time%3B%2Cc0)
![Screenshot 2022-03-26 at 15-05-35 Google Books Ngram Viewer](https://user-images.githubusercontent.com/177011/160243117-916b9be8-3a4d-4177-b71f-d1581c6e37bb.png)
