### PR TITLE
wildcard: drop the space between wild and card

### DIFF
--- a/badwords.txt
+++ b/badwords.txt
@@ -1,15 +1,16 @@
-back-end
-e-mail
-run-time
-set-up
-toolchain
-tool-chain
-wildcard
-I'm
-You've
-They're
-should've
-don't
-could've
-doesn't
-isn't
+back-end:backend
+e-mail:email
+run-time:runtime
+set-up:setup
+toolchain:tool chain
+tool-chain:tool chain
+wild-card:wildcard
+wild card:wildcard
+I'm:I am
+You've:You have
+They're:They are
+should've:should have
+don't:do not
+could've:could have
+doesn't:does not
+isn't:is not

--- a/libcurl/callbacks.md
+++ b/libcurl/callbacks.md
@@ -30,7 +30,7 @@ legal to invoke libcurl functions from within a libcurl callback.
  * [Opensocket and closesocket](callbacks/openclosesocket.md)
  * [SSH key](callbacks/sshkey.md)
  * [RTSP interleaved data](callbacks/rtsp.md)
- * [FTP wild card matching](callbacks/ftpmatch.md)
+ * [FTP wildcard matching](callbacks/ftpmatch.md)
  * [Resolver start](callbacks/resolver.md)
  * [Sending trailers](callbacks/trailers.md)
  * [HSTS](callbacks/hsts.md)

--- a/libcurl/callbacks/ftpmatch.md
+++ b/libcurl/callbacks/ftpmatch.md
@@ -1,12 +1,12 @@
-# FTP wild card matching
+# FTP wildcard matching
 
-libcurl supports FTP wild card matching. You use this feature by setting
-`CURLOPT_WILDCARDMATCH` to `1L` and then use a "wild card pattern" in the in
+libcurl supports FTP wildcard matching. You use this feature by setting
+`CURLOPT_WILDCARDMATCH` to `1L` and then use a "wildcard pattern" in the in
 the file name part of the URL.
 
-## Wild card patterns
+## Wildcard patterns
 
-The default libcurl wild card matching function supports:
+The default libcurl wildcard matching function supports:
 
 `*` - ASTERISK
 
@@ -48,7 +48,7 @@ Using the rules above, a file name pattern can be constructed:
 
 ## FTP chunk callbacks
 
-When FTP wild card matching is used, the `CURLOPT_CHUNK_BGN_FUNCTION` callback
+When FTP wildcard matching is used, the `CURLOPT_CHUNK_BGN_FUNCTION` callback
 is called before a transfer is initiated for a file that matches.
 
 The callback can then opt to return one of these return codes to tell libcurl

--- a/mgrep
+++ b/mgrep
@@ -4,7 +4,11 @@ open(P, "<badwords.txt");
 my $w;
 while(<P>) {
     chomp;
-    push @w, $_ if($_);
+    if($_ =~ /^([^:]*):(.*)/) {
+        my ($bad, $better)=($1, $2);
+        push @w, $bad;
+        $alt{$bad} = $better;
+    }
 }
 close(P);
 
@@ -28,8 +32,12 @@ sub file {
         foreach my $w (@w) {
             if($in =~ /^(.*)$w/i) {
                 my $p = $1;
-                print STDERR "$f:$l $in\n";
-                printf STDERR "$f:$l %*s^ (found $w)\n", length($p), " ";
+                my $c = length($p)+1;
+                print STDERR  "$f:$l:$c: error: found bad word \"$w\"\n";
+                printf STDERR " %4d | $in\n", $l;
+                printf STDERR "      | %*s^%s\n", length($p), " ",
+                    "~" x (length($w)-1);
+                printf STDERR " maybe use \"%s\" instead?\n", $alt{$w};
                 $errors++;
             }
         }


### PR DESCRIPTION
Because that's the more common way to write it.

Also extended mgrep to do better errors. 'badwords' now also provide a
suggested replacement.

![Screenshot 2022-03-26 at 18-27-09 Google Books Ngram Viewer](https://user-images.githubusercontent.com/177011/160250658-43c64d69-7233-4c67-ba6f-3956d8b8166f.png)
