### PR TITLE
badwords: prefer "toolchain"

### DIFF
--- a/badwords.txt
+++ b/badwords.txt
@@ -2,8 +2,8 @@ back-end:backend
 e-mail:email
 run-time:runtime
 set-up:setup
-toolchain:tool chain
-tool-chain:tool chain
+tool chain:toolchain
+tool-chain:toolchain
 wild-card:wildcard
 wild card:wildcard
 i'm:I am

--- a/get/win-msys2.md
+++ b/get/win-msys2.md
@@ -68,4 +68,4 @@ docs](https://www.msys2.org/docs/package-management/) or join the
 pacman and msys2!
 
 
-[^1]: Be careful not to confuse the [mingw-package](https://github.com/msys2/MINGW-packages) `mingw-w64-curl` with the [msys-packages](https://github.com/msys2/MSYS2-packages) `curl` and `curl-devel`. The latter are part of msys2 environment itself (e.g. to support pacman downloads), but not suitable for redistribution. To build redistributable software that does not depend on MSYS2 itself, you always need `mingw-w64-…` packages and tool chains.
+[^1]: Be careful not to confuse the [mingw-package](https://github.com/msys2/MINGW-packages) `mingw-w64-curl` with the [msys-packages](https://github.com/msys2/MSYS2-packages) `curl` and `curl-devel`. The latter are part of msys2 environment itself (e.g. to support pacman downloads), but not suitable for redistribution. To build redistributable software that does not depend on MSYS2 itself, you always need `mingw-w64-…` packages and toolchains.


### PR DESCRIPTION
... over separated of hyphened versions. It makes this consistent with other
recent updates and also goes with the popular way of spelling it.

[graph](https://books.google.com/ngrams/graph?content=tool+chain%2Ctoolchain%2Ctool-chain&year_start=1980&year_end=2019&corpus=26&smoothing=3&direct_url=t1%3B%2Ctool%20chain%3B%2Cc0%3B.t1%3B%2Ctoolchain%3B%2Cc0%3B.t1%3B%2Ctool%20-%20chain%3B%2Cc0)

![Screenshot 2022-03-29 at 11-11-30 Google Books Ngram Viewer](https://user-images.githubusercontent.com/177011/160577166-32a7f3cb-aff1-4146-a507-430d3669ee55.png)
