### PR TITLE
docs: Example for uploading multiple files to FTP

### DIFF
--- a/ftp/upload.md
+++ b/ftp/upload.md
@@ -15,9 +15,13 @@ or to use the local file name as the remote name:
     curl -T localfile ftp://ftp.example.com/dir/path/
 
 curl also supports [globbing](../cmdline/globbing.md) in the `-T` argument so
-you can opt to easily upload a range or a series of files:
+you can opt to easily upload a range of files:
 
     curl -T 'image[1-99].jpg' ftp://ftp.example.com/upload/
+
+or a series of files:
+
+    curl -T '{file1,file2}' ftp://ftp.example.com/upload/
 
 or
 


### PR DESCRIPTION
Took me a while to get this one. I wanted to upload multiple files in a single go (to reuse existing connection) and found [answer here](https://unix.stackexchange.com/questions/315424/uploading-multiple-files-via-ftp-using-curl). Would be nice to be part of these docs as well.