### PR TITLE
verbose/writeout.md: clarify Windows % symbol escaping

### DIFF
--- a/usingcurl/verbose/writeout.md
+++ b/usingcurl/verbose/writeout.md
@@ -23,9 +23,6 @@ the string and that variable will then be substituted by the correct value. To
 output a normal '%' you just write it as '%%'. You can also output a newline
 by using '\n', a carriage return with '\r' and a tab space with '\t'.
 
-(The %-symbol is special on the Windows command line, where all occurrences of
-% must be doubled when using this option.)
-
 As an example, we can output the Content-Type and the response code from an
 HTTP transfer, separated with newlines and some extra text like this:
 
@@ -34,6 +31,11 @@ HTTP transfer, separated with newlines and some extra text like this:
 This feature writes the output to stdout so you probably want to make sure
 that you do not also send the downloaded content to stdout as then you might
 have a hard time to separate out the data.
+
+**NOTE:** In Windows the %-symbol is a special symbol used to expand
+environment variables. In batch files all occurrences of % must be doubled when
+using this option to properly escape. If this option is used at the command
+prompt then the % cannot be escaped and unintended expansion is possible.
 
 ## Available --write-out variables
 


### PR DESCRIPTION
- Clarify that in Windows batch files the % must be escaped as %%, and at the command prompt it cannot be escaped which could lead to incorrect expansion.

Prior to this change the doc implied % must be escaped as %% in win32 always.

---

Examples:

If curl --write-out "%{http_code}" is executed in a batch file: {http_code}

If curl --write-out "%%{http_code}" is executed in a batch file: %{http_code}

If curl --write-out "%{http_code}" is executed from the command prompt: %{http_code}

If curl --write-out "%%{http_code}" is executed from the command prompt: %%{http_code}

At the command prompt something like "%{speed_download}%{http_code}" would first be parsed by the command interpreter as %{speed_download}% and would be expanded as environment variable {speed_download} if it existed, though that's highly unlikely since Windows environment names don't use braces.

---

Reported-by: Muhammad Hussein Ammari

Ref: https://github.com/curl/curl/pull/10337

Fixes https://github.com/curl/curl/issues/10323
Closes #xxxx