### PR TITLE
macos.md: Detailed installation instructions

### DIFF
--- a/get/macos.md
+++ b/get/macos.md
@@ -6,6 +6,14 @@ project, we recommend installing [homebrew](https://brew.sh/) (a macOS
 software package manager) and then install the curl package from them:
 
     brew install curl
+    
+Note however that when installing curl, brew does not create a `curl` symlink
+in the default homebrew folder, to avoid clashes with the macOS version of curl.
+
+Check the output of the command above, which should give you a command to execute
+to make brew curl the default one in your shell, depending on your homebrew prefix
+(for example, on Apple silicon, you'd have to run `echo 'export PATH="/opt/homebrew/opt/curl/bin:$PATH"' >> ~/.zshrc`).
+
 
 ## Get libcurl for macOS
 

--- a/get/macos.md
+++ b/get/macos.md
@@ -7,12 +7,13 @@ software package manager) and then install the curl package from them:
 
     brew install curl
     
-Note however that when installing curl, brew does not create a `curl` symlink
+Note that when installing curl, brew does not create a `curl` symlink
 in the default homebrew folder, to avoid clashes with the macOS version of curl.
 
-Check the output of the command above, which should give you a command to execute
-to make brew curl the default one in your shell, depending on your homebrew prefix
-(for example, on Apple silicon, you'd have to run `echo 'export PATH="/opt/homebrew/opt/curl/bin:$PATH"' >> ~/.zshrc`).
+Run the following to make brew curl the default one:
+
+    echo 'export PATH="$(brew --prefix)/opt/curl/bin:$PATH"' >> ~/.zshrc`
+    source ~/.zshrc
 
 
 ## Get libcurl for macOS

--- a/get/macos.md
+++ b/get/macos.md
@@ -10,7 +10,7 @@ software package manager) and then install the curl package from them:
 Note that when installing curl, brew does not create a `curl` symlink
 in the default homebrew folder, to avoid clashes with the macOS version of curl.
 
-Run the following to make brew curl the default one:
+Run the following to make brew curl the default one in your shell:
 
     echo 'export PATH="$(brew --prefix)/opt/curl/bin:$PATH"' >> ~/.zshrc`
     source ~/.zshrc


### PR DESCRIPTION
The MacOS installation docs tell to use `brew install curl`.

Normally when something is installed with brew, it also creates a symlink to the installed tool in a location that is added to `PATH` during brew installation, so the tool is usable immediately.

However this is not the case with `curl`:

The output of `brew install curl` prints the info about not creating a symlink, but it's not very eye-catching, so I think it's worth emphasising this more in curl docs.

```
brew install curl
```

```
(...super long output as all dependencies are fetched and installed first)
(...finally)

==> Caveats
curl is keg-only, which means it was not symlinked into /opt/homebrew,
because macOS already provides this software and installing another version in
parallel can cause all kinds of trouble.

If you need to have curl first in your PATH, run:
  echo 'export PATH="/opt/homebrew/opt/curl/bin:$PATH"' >> ~/.zshrc
```

(note: the folder above will be different on Mac Intel vs Mac Apple Silicon)