### PR TITLE
markdown: make all links single-line

### DIFF
--- a/build.md
+++ b/build.md
@@ -68,9 +68,8 @@ running `autoreconf -fi` and on Windows, run `buildconf.bat`.
 ## On Linux and Unix-like systems
 
 There are two distinctly different ways to build curl on Linux and other
-Unix-like systems; there is the one using [the configure
-script](build/autotools.md) and there is [the CMake
-approach](build/cmake.md).
+Unix-like systems; there is the one using [the configure script](build/autotools.md)
+and there is [the CMake approach](build/cmake.md).
 
 There are two different build environments to cater to people's different
 opinions and tastes. The configure-based build is arguably the more mature and

--- a/cmdline/differences.md
+++ b/cmdline/differences.md
@@ -36,5 +36,5 @@ PowerShell, you need to type in its full name including the extension:
 Different command-line environments will also have different maximum command
 line lengths and force the users to limit how large amount of data that can be
 put into a single line. curl adapts to this by offering a way to provide
-command-line options through a file or stdin using the [-K
-option](configfile.md).
+command-line options through a file or stdin using the
+[-K option](configfile.md).

--- a/cmdline/passwords.md
+++ b/cmdline/passwords.md
@@ -22,10 +22,9 @@ will help minimize that risk by trying to blank out passwords from process
 listings.
 
 One way to avoid passing the user name and password on the command line is to
-instead use a [.netrc file](../usingcurl/netrc.md) or a [config
-file](configfile.md). You can also use the `-u` option without
-specifying the password, and then curl will instead prompt the user for it
-when it runs.
+instead use a [.netrc file](../usingcurl/netrc.md) or a [config file](configfile.md).
+You can also use the `-u` option without specifying the password, and then
+curl will instead prompt the user for it when it runs.
 
 ## Network leakage
 

--- a/http/http2.md
+++ b/http/http2.md
@@ -30,5 +30,5 @@ your machines) you can shortcut the HTTP/2 "negotiation" with
 
 A primary feature in the HTTP/2 protocol, is the ability to multiplex several
 logical streams over the same physical connection. The curl command-line tool
-can take advantage of this feature when [doing parallel
-transfers](../cmdline/urls/parallel.md).
+can take advantage of this feature when
+[doing parallel transfers](../cmdline/urls/parallel.md).

--- a/http/multipart.md
+++ b/http/multipart.md
@@ -54,8 +54,8 @@ request headers to the host example.com:
 **Content-Length**, of course, tells the server how much data to expect. This
 example's 313 bytes is really small.
 
-The **Expect** header is explained in the [Expect 100
-continue](post/expect100.md) chapter.
+The **Expect** header is explained in the [Expect 100 continue](post/expect100.md)
+chapter.
 
 The **Content-Type** header is a bit special. It tells that this is a
 multipart formpost and then it sets the "boundary" string. The boundary string
@@ -112,9 +112,9 @@ to submit a multipart form as seen in HTML.
 
 2. Use the "development tools" in your favorite browser and inspect the POST
    request in the network tab after you have submitted it. Then convert that
-   HTTP data to a curl command line. Unfortunately, the [copy as
-   curl](../usingcurl/copyas.md) feature in the browsers usually do not actually
-   do multipart formposts particularly well.
+   HTTP data to a curl command line. Unfortunately, the
+   [copy as curl](../usingcurl/copyas.md) feature in the browsers usually do
+   not actually do multipart formposts particularly well.
 
 3. Inspect the source HTML and convert into a curl command line directly from
    that.

--- a/http/post/javascript.md
+++ b/http/post/javascript.md
@@ -8,6 +8,6 @@ value that the server then can verify before it considers the submission to be
 valid.
 
 You can usually work around that by just reading the JavaScript code and
-redoing that logic in your script. Using the tricks in [Figure out what a
-browser sends](browsersends.md) to check exactly what a browser sends is then
-also a good help.
+redoing that logic in your script. Using the tricks in
+[Figure out what a browser sends](browsersends.md) to check exactly what a
+browser sends is then also a good help.

--- a/http/postvspost.md
+++ b/http/postvspost.md
@@ -1,8 +1,8 @@
 # -d vs -F
 
-Previous chapters talked about [regular POST](post.md) and [multipart
-formpost](multipart.md), and in your typical command lines you do them with
-`-d` or `-F`.
+Previous chapters talked about [regular POST](post.md) and
+[multipart formpost](multipart.md), and in your typical command lines you do
+them with `-d` or `-F`.
 
 When do you use which of them?
 

--- a/internals/tests/curl.md
+++ b/internals/tests/curl.md
@@ -12,5 +12,5 @@ The `tests/log/commands.log` is handy to look at after a run, as it contains
 the full command line that was run in the test.
 
 If you want to make a test that does not invoke the curl command line tool,
-then you should consider the [libcurl tests](libcurl.md) or [unit
-tests](unit.md) instead.
+then you should consider the [libcurl tests](libcurl.md) or
+[unit tests](unit.md) instead.

--- a/libcurl-http.md
+++ b/libcurl-http.md
@@ -1,8 +1,9 @@
 # HTTP with libcurl
 
 HTTP is by far the most commonly used protocol by libcurl users and libcurl
-offers countless ways of modifying such transfers. See the [HTTP protocol
-basics](http/basics.md) for some basics on how the HTTP protocol works.
+offers countless ways of modifying such transfers. See the
+[HTTP protocol basics](http/basics.md) for some basics on how the HTTP protocol
+works.
 
 ## HTTPS
 
@@ -10,8 +11,8 @@ Doing HTTPS is typically done the same way as for HTTP as the extra security
 layer and server verification etc is done automatically and transparently by
 default. Just use the `https://` scheme in the URL.
 
-HTTPS is HTTP with TLS on top. See also the [TLS
-options](libcurl/options/tls.md) section.
+HTTPS is HTTP with TLS on top. See also the [TLS options](libcurl/options/tls.md)
+section.
 
 ## HTTP proxy
 

--- a/libcurl-http/auth.md
+++ b/libcurl-http/auth.md
@@ -4,8 +4,8 @@ libcurl supports a wide variety of HTTP authentication schemes.
 
 Note that this way of authentication is different than the otherwise widely
 used scheme on the web today where authentication is performed by an HTTP POST
-and then keeping state in cookies. See [Cookies with
-libcurl](cookies.md) for details on how to do that.
+and then keeping state in cookies. See [Cookies with libcurl](cookies.md)
+for details on how to do that.
 
 ## User name and password
 

--- a/libcurl-http/responses.md
+++ b/libcurl-http/responses.md
@@ -7,9 +7,8 @@ headers.
 
 ## Response body
 
-The response body will be passed to the [write
-callback](../libcurl/callbacks/write.md) and the response headers to the
-[header callback](../libcurl/callbacks/header.md).
+The response body will be passed to the [write callback](../libcurl/callbacks/write.md)
+and the response headers to the [header callback](../libcurl/callbacks/header.md).
 
 Virtually all libcurl-using applications need to set at least one of those
 callbacks instructing libcurl what to do with received headers and data.

--- a/libcurl-http/upload.md
+++ b/libcurl-http/upload.md
@@ -18,8 +18,7 @@ server. With libcurl you normally provide that data as a pointer and a length:
     curl_easy_setopt(easy, CURLOPT_POSTFIELDSIZE, (long)datalength);
 
 Or you tell libcurl that it is a post but would prefer to have libcurl instead
-get the data by using the regular [read
-callback](../libcurl/callbacks/read.md):
+get the data by using the regular [read callback](../libcurl/callbacks/read.md):
 
     curl_easy_setopt(easy, CURLOPT_POST, 1L);
     curl_easy_setopt(easy, CURLOPT_READFUNCTION, read_callback);

--- a/libcurl/caches.md
+++ b/libcurl/caches.md
@@ -7,8 +7,8 @@ When the multi interface is used, these caches are by default shared among all
 the easy handles that are added to that single multi handle, and when the easy
 interface is used they are kept within that handle.
 
-You can instruct libcurl to share some of the caches with the [share
-interface](sharing.md).
+You can instruct libcurl to share some of the caches with the
+[share interface](sharing.md).
 
 ## DNS cache
 

--- a/libcurl/connectionreuse.md
+++ b/libcurl/connectionreuse.md
@@ -31,6 +31,5 @@ later transfer. Just reuse the multi handle!
 
 ## Sharing the "connection cache"
 
-Since libcurl 7.57.0, applications can use the [share
-interface](sharing.md) to have otherwise independent transfers share
-the same connection pool.
+Since libcurl 7.57.0, applications can use the [share interface](sharing.md)
+to have otherwise independent transfers share the same connection pool.

--- a/libcurl/drive/multi-socket.md
+++ b/libcurl/drive/multi-socket.md
@@ -1,8 +1,8 @@
 # Driving with the "multi_socket" interface
 
 multi_socket is the extra spicy version of the regular multi interface and is
-designed for event-driven applications. Make sure you read the [Drive with
-multi interface](multi.md) section first.
+designed for event-driven applications. Make sure you read the
+[Drive with multi interface](multi.md) section first.
 
 multi_socket supports multiple parallel transfers—all done in the same
 single thread—and have been used to run several tens of thousands of

--- a/libcurl/easyhandle.md
+++ b/libcurl/easyhandle.md
@@ -37,8 +37,7 @@ variety of things.
 
 After the transfer has completed, you can figure out if it succeeded or not
 and you can extract statistics and other information that libcurl gathered
-during the transfer from the easy handle. See [Post transfer
-information](getinfo.md).
+during the transfer from the easy handle. See [Post transfer information](getinfo.md).
 
 ## Reuse
 

--- a/libcurl/examples/get.md
+++ b/libcurl/examples/get.md
@@ -7,8 +7,8 @@ By replacing the URL this will of course be able to get contents over other
 supported protocols as well.
 
 Getting the output sent to stdout is a default behavior and usually not what
-you actually want. Most applications will instead install a [write
-callback](../callbacks/write.md) to have receive the data that arrives.
+you actually want. Most applications will instead install a
+[write callback](../callbacks/write.md) to have receive the data that arrives.
 
     #include <stdio.h>
     #include <curl/curl.h>

--- a/libcurl/names.md
+++ b/libcurl/names.md
@@ -5,12 +5,12 @@ translated to an Internet address. That is "name resolving". Using a numerical
 IP address directly in the URL usually avoids the name resolve phase, but in
 many cases it is not easy to manually replace the name with the IP address.
 
-libcurl tries hard to [re-use an existing
-connection](connectionreuse.md) rather than to create a new one. The
-function that checks for an existing connection to use is based purely on the
-name and is performed before any name resolving is attempted. That is one of
-the reasons the re-use is so much faster. A transfer using a reused connection
-will not resolve the host name again.
+libcurl tries hard to [re-use an existing connection](connectionreuse.md)
+rather than to create a new one. The function that checks for an existing
+connection to use is based purely on the name and is performed before any name
+resolving is attempted. That is one of the reasons the re-use is so much
+faster. A transfer using a reused connection will not resolve the host name
+again.
 
 If no connection can be reused, libcurl resolves the host name to the set of
 addresses it resolves to. Typically this means asking for both IPv4 and IPv6
@@ -68,8 +68,7 @@ cache for 60 seconds, but that value can be changed with
 
 The DNS cache is kept within the easy handle when `curl_easy_perform` is used,
 or within the multi handle when the multi interface is used. It can also be
-made shared between multiple easy handles using the [share
-interface](sharing.md).
+made shared between multiple easy handles using the [share interface](sharing.md).
 
 ## Custom addresses for hosts
 

--- a/libcurl/ws/read.md
+++ b/libcurl/ws/read.md
@@ -35,5 +35,4 @@ The `curl_ws_recv` function has this prototype:
 
 `recv` - the size in bytes of the data stored in the **buffer* on return
 
-`meta` - gets a pointer to a struct with [information about the received
-frame](meta.md).
+`meta` - gets a pointer to a struct with [information about the received frame](meta.md).

--- a/source/contributing.md
+++ b/source/contributing.md
@@ -178,8 +178,7 @@ to be pushed by a trusted person.
 The core team is a small set of curl developers who have been around for
 several years and have shown they are skilled developers and that they fully
 comprehend the values and the style of development we do in this project. They
-are some of the people listed in the [The development
-team](../project/devteam.md) section.
+are some of the people listed in the [The development team](../project/devteam.md) section.
 
 You can always bring a discussion to the mailing list and argue why you think
 your changes should get accepted, or perhaps even object to other changes that

--- a/usingcurl/downloads/whatis.md
+++ b/usingcurl/downloads/whatis.md
@@ -6,11 +6,11 @@ download. In this example the URL to download is `http://example.com`:
 
     curl http://example.com
 
-The URL is broken down into its individual components ([as explained
-elsewhere](../../cmdline/urls.md)), the correct server is contacted and is
-then asked to deliver the specific resource—often a file. The server then
-delivers the data, or it refuses or perhaps the client asked for the wrong
-data and then that data is delivered.
+The URL is broken down into its individual components
+([as explained elsewhere](../../cmdline/urls.md)), the correct server is
+contacted and is then asked to deliver the specific resource—often a file. The
+server then delivers the data, or it refuses or perhaps the client asked for
+the wrong data and then that data is delivered.
 
 A request for a resource is protocol-specific so an `FTP://` URL works
 differently than an `HTTP://` URL or an `SFTP://` URL.

--- a/usingcurl/uploads.md
+++ b/usingcurl/uploads.md
@@ -29,8 +29,8 @@ receiver.
 The upload kind is usually done with the `-d` or `--data` options, but there
 are a few additional alterations.
 
-Read the detailed description on how to do this with curl in the [HTTP POST
-with curl](../http/post.md) chapter.
+Read the detailed description on how to do this with curl in the
+[HTTP POST with curl](../http/post.md) chapter.
 
 ### multipart formpost
 
@@ -83,13 +83,12 @@ body as curl will not add any at all.
 
     curl -T mail smtp://mail.example.com/ --mail-from user@example.com
 
-Learn more about using SMTP with curl in the [Using
-curl/SMTP](smtp.md) section.
+Learn more about using SMTP with curl in the [Using curl/SMTP](smtp.md) section.
 
 ## Progress meter for uploads
 
-The general progress meter curl provides (see the [Progress
-meter](../cmdline/progressmeter.md) section) works fine for uploads as well.
+The general progress meter curl provides (see the
+[Progress meter](../cmdline/progressmeter.md) section) works fine for uploads as well.
 What needs to be remembered is that the progress meter is automatically
 disabled when you are sending output to stdout, and most protocols curl
 support can output something even for an upload.


### PR DESCRIPTION
To allow scripts to better deal with them