### PR TITLE
Correct link to http3.md

### DIFF
--- a/http/versions.md
+++ b/http/versions.md
@@ -24,4 +24,4 @@ Non-HTTP/2 capable curls get 1.1 over HTTPS by default.
 
 * [HTTP/0.9](versions/http09.md)
 * [HTTP/2](versions/http2.md)
-* [HTTP/3](versions/http2.md)
+* [HTTP/3](versions/http3.md)


### PR DESCRIPTION
Updates the link to the HTTP/3 document to correctly point to http3.md