### PR TITLE
build/separate.md: explain rpath vs runpath

### DIFF
--- a/build/separate.md
+++ b/build/separate.md
@@ -85,7 +85,8 @@ looks something like this:
 If your system supports the runpath form of rpath it is often better to use
 that instead because it can be overridden by the `LD_LIBRARY_PATH` environment
 variable. It may also prevent libtool bugs when testing in-tree builds of curl,
-since then libtool can use `LD_LIBRARY_PATH`. To use an rpath as a runpath add
-the linker flag `-Wl,--enable-new-dtags` like this:
+since then libtool can use `LD_LIBRARY_PATH`. Newer linkers may use the runpath
+form of rpath by default when rpath is specified but others need an additional
+linker flag `-Wl,--enable-new-dtags` like this:
 
     LDFLAGS="-Wl,-rpath,$HOME/install/lib -Wl,--enable-new-dtags" ./configure ...

--- a/build/separate.md
+++ b/build/separate.md
@@ -81,3 +81,11 @@ install them into `$HOME/install`, then a configure command line for this
 looks something like this:
 
     LDFLAGS="-Wl,-rpath,$HOME/install/lib" ./configure ...
+
+If your system supports the runpath form of rpath it is often better to use
+that instead because it can be overridden by the LD_LIBRARY_PATH environment
+variable. It may also prevent libtool bugs when testing in-tree builds of curl,
+since then libtool can use LD_LIBRARY_PATH. To use an rpath as a runpath add
+the linker flag `-Wl,--enable-new-dtags` like this:
+
+    LDFLAGS="-Wl,-rpath,$HOME/install/lib -Wl,--enable-new-dtags" ./configure ...

--- a/build/separate.md
+++ b/build/separate.md
@@ -83,9 +83,9 @@ looks something like this:
     LDFLAGS="-Wl,-rpath,$HOME/install/lib" ./configure ...
 
 If your system supports the runpath form of rpath it is often better to use
-that instead because it can be overridden by the LD_LIBRARY_PATH environment
+that instead because it can be overridden by the `LD_LIBRARY_PATH` environment
 variable. It may also prevent libtool bugs when testing in-tree builds of curl,
-since then libtool can use LD_LIBRARY_PATH. To use an rpath as a runpath add
+since then libtool can use `LD_LIBRARY_PATH`. To use an rpath as a runpath add
 the linker flag `-Wl,--enable-new-dtags` like this:
 
     LDFLAGS="-Wl,-rpath,$HOME/install/lib -Wl,--enable-new-dtags" ./configure ...

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -259,6 +259,7 @@ kubernetes
 Kuhrt
 Largefile
 LASTSOCKET
+LD
 LDAP
 ldap
 LDAPS
@@ -282,6 +283,7 @@ libs
 libssh
 libSSH
 libssh2
+libtool
 libuv
 libz
 libzstd
@@ -416,12 +418,14 @@ Rikard
 ROADMAP
 Rockbox
 roffit
+rpath
 RTMP
 rtmp
 RTMPS
 RTP
 RTSP
 rtsp
+runpath
 runtests
 runtime
 Ruslan

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -259,7 +259,6 @@ kubernetes
 Kuhrt
 Largefile
 LASTSOCKET
-LD
 LDAP
 ldap
 LDAPS

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -286,6 +286,7 @@ libtool
 libuv
 libz
 libzstd
+linkers
 linux
 localhost
 logfile


### PR DESCRIPTION
- Explain that LD_LIBRARY_PATH can override runpath but not rpath.

.. because using runpath solved some in-tree curl testing problems I had with libtool, so I figure other users may benefit from knowing about it.

Ref: https://github.com/curl/curl/issues/432#issuecomment-244818726

Closes #xxxx