### PR TITLE
all: use 4 space indents for examples

### DIFF
--- a/http/browserlike.md
+++ b/http/browserlike.md
@@ -53,13 +53,11 @@ exact URL to send the POST to, using the `action` parameter.
 
 In our imaginary case, the form tag looks like this:
 
-~~~
-<form action="login.cgi" method="POST">
-  <input type="text" name="user">
-  <input type="password" name="secret">
-  <input type="hidden" name="id" value="bc76">
-</form>
-~~~
+    <form action="login.cgi" method="POST">
+      <input type="text" name="user">
+      <input type="password" name="secret">
+      <input type="hidden" name="id" value="bc76">
+    </form>
 
 There are three fields of importance. **text**, **secret** and **id**. The
 last one, the id, is marked `hidden` which means that it will not show up in

--- a/http/multipart.md
+++ b/http/multipart.md
@@ -7,13 +7,12 @@ separated with MIME boundaries.
 
 An example piece of HTML would look like this:
 
-~~~
-<form action="submit.cgi" method="post" enctype="multipart/form-data">
-  Name: <input type="text" name="person"><br>
-  File: <input type="file" name="secret"><br>
-  <input type="submit" value="Submit">
-</form>
-~~~
+    <form action="submit.cgi" method="post" enctype="multipart/form-data">
+      Name: <input type="text" name="person"><br>
+      File: <input type="file" name="secret"><br>
+      <input type="submit" value="Submit">
+    </form>
+
 Which could look something like this in a web browser:
 
 ![a multipart form](multipart-form.png)

--- a/libcurl/control/meter.md
+++ b/libcurl/control/meter.md
@@ -9,7 +9,6 @@ Return error to stop transfer
 
 ## Example
 
-~~~c
     #include <stdio.h>
     #include <curl/curl.h>
 

--- a/libcurl/control/ratelimit.md
+++ b/libcurl/control/ratelimit.md
@@ -9,7 +9,6 @@ sending (`CURLOPT_MAX_SEND_SPEED_LARGE`).
 
 ## Example
 
-~~~c
     #include <stdio.h>
     #include <curl/curl.h>
 

--- a/libcurl/ws/meta.md
+++ b/libcurl/ws/meta.md
@@ -7,14 +7,12 @@ fragment. It *can* be a whole fragment, but it might only be a piece of
 it. The `curl_ws_frame` contains information about the frame to tell you the
 details.
 
-~~~c
-struct curl_ws_frame {
-  int age;              /* zero */
-  int flags;            /* See the CURLWS_* defines */
-  curl_off_t offset;    /* the offset of this data into the frame */
-  curl_off_t bytesleft; /* number of pending bytes left of the payload */
-};
-~~~
+    struct curl_ws_frame {
+      int age;              /* zero */
+      int flags;            /* See the CURLWS_* defines */
+      curl_off_t offset;    /* the offset of this data into the frame */
+      curl_off_t bytesleft; /* number of pending bytes left of the payload */
+    };
 
 ## `age`
 

--- a/usingcurl/telnet.md
+++ b/usingcurl/telnet.md
@@ -33,16 +33,15 @@ request to it by manually entering `GET /` and press return twice:
     curl telnet://localhost:80
 
 Your web server will most probably return something like this back:
-~~~
-HTTP/1.1 400 Bad Request
-Date: Tue, 07 Dec 2021 07:41:16 GMT
-Server: softeare/7.8.9
-Content-Length: 31
-Connection: close
-Content-Type: text/html
 
-[message]
-~~~
+    HTTP/1.1 400 Bad Request
+    Date: Tue, 07 Dec 2021 07:41:16 GMT
+    Server: softeare/7.8.9
+    Content-Length: 31
+    Connection: close
+    Content-Type: text/html
+
+    [message]
 
 ## Options
 

--- a/usingcurl/verbose.md
+++ b/usingcurl/verbose.md
@@ -15,17 +15,13 @@ example (saving the downloaded data in the file called 'saved'):
 Ok so we invoked curl with a URL that it considers incomplete so it helps us
 and it adds a trailing slash before it moves on.
 
-~~~
     *   Trying 93.184.216.34...
-~~~
 
 This tells us curl now tries to connect to this IP address. It means the name
 'example.com' has been resolved to one or more addresses and this is the first
 (and possibly only) address curl will try to connect to.
 
-~~~
     * Connected to example.com (93.184.216.34) port 80 (#0)
-~~~
 
 It worked! curl connected to the site and here it explains how the name maps
 to the IP address and on which port it has connected to. The '(#0)' part is
@@ -47,13 +43,11 @@ responses as headers and they will thus also be shown with -v.
 If we then continue the output seen from the command above (but ignore the
 actual HTML response), curl will show:
 
-~~~
     > GET / HTTP/1.1
     > Host: example.com
     > User-Agent: curl/7.45.0
     > Accept: */*
     >
-~~~
 
 This is the full HTTP request to the site. This request is how it looks
 in a default curl 7.45.0 installation and it may, of course, differ slightly


### PR DESCRIPTION
No other markdown escaping mechanisms for consistency. Also avoid "~~~c" simply because it does not work across all output versions we do.