### PR TITLE
misc: avoid "example" as subtitle

### DIFF
--- a/cmdline/configfile.md
+++ b/cmdline/configfile.md
@@ -1,18 +1,23 @@
 # Config file
 
-Curl commands with multiple command-line options can become cumbersome to work with. The number of characters can even exceed the maximum length allowed by your terminal application. 
+Curl commands with multiple command-line options can become cumbersome to work
+with. The number of characters can even exceed the maximum length allowed by
+your terminal application.
 
-To aid such situations, curl allows you to write command-line options in a plain text config file and tell curl to read options from that file when applicable. 
+To aid such situations, curl allows you to write command-line options in a
+plain text config file and tell curl to read options from that file when
+applicable.
 
-You can also use config files to assign data to variables and transform the data with functions, making them incredibly useful. This is discussed in the ["Variables"](https://everything.curl.dev/cmdline/variables) section.
+You can also use config files to assign data to variables and transform the
+data with functions, making them incredibly useful. This is discussed in the
+["Variables"](https://everything.curl.dev/cmdline/variables) section.
 
-Some examples below contain multiple lines for readability. The forward slash (`\`) is used to instruct the terminal to ignore the newline.
+Some examples below contain multiple lines for readability. The forward slash
+(`\`) is used to instruct the terminal to ignore the newline.
 
-## Options
+## Specify the config file to use
 
 Using the `-K` or long form `--config` option tells curl to read from a config file.
-
-## Example 1
 
     curl  \
         --config configFile.txt \
@@ -27,7 +32,6 @@ simplicity in the example above.
 
 Enter one command per line. Use a hash symbol for comments:
 
-
     # curl config file
 
     # Follow redirects
@@ -36,15 +40,12 @@ Enter one command per line. Use a hash symbol for comments:
     # Do a HEAD request
     --head
 
-
-### Command line options
+## Command line options
 
 You can use both short and long options, exactly as you would write them on a command line. 
 
 You can also write the long option WITHOUT the leading two dashes to make
 it easier to read. 
-
-### Example 1
 
     # curl config file
 
@@ -54,12 +55,10 @@ it easier to read.
     # Do a HEAD request
     head
 
-### Arguments
+## Arguments
 
 A command line option that takes an argument must have its argument provided on
 the SAME LINE as the option. 
-
-#### Example 1
 
     # curl config file
 
@@ -69,15 +68,12 @@ You can also use `=` or `:` between the option and its argument. As you see
 above, it is not necessary, but some like the clarity it offers. Setting the
 user-agent option again:
 
-#### Example 2
-
     # curl config file
 
     user-agent = "Everything-is-an-agent"
 
-The user agent string example we have used above has no white spaces, so the quotes are technically not needed:
-
-#### Example 3
+The user agent string example we have used above has no white spaces, so the
+quotes are technically not needed:
 
     # curl config file
 
@@ -85,17 +81,17 @@ The user agent string example we have used above has no white spaces, so the quo
 
 See ["When to use quotes"](#when-to-use-quotes) for more info on when quotes should be used.
 
-### URLs
+## URLs
 
-When entering URLs at the command line, everything that is not an option is assumed to be a URL. However, in a config file, you must specify a URL with `--url` or `url`.
-
-#### Example 1
+When entering URLs at the command line, everything that is not an option is
+assumed to be a URL. However, in a config file, you must specify a URL with
+`--url` or `url`.
 
     # curl config file
 
     url = https://example.com
 
-### When to use quotes
+## When to use quotes
 
 You need to use double quotes when:
 

--- a/cmdline/variables.md
+++ b/cmdline/variables.md
@@ -13,18 +13,17 @@ gets overwritten with new content. Variable names are case sensitive, can be
 up to 128 characters long and may consist of the characters a-z, A-Z, 0-9 and
 underscore.
 
-Some examples below contain multiple lines for readability. The forward slash (`\`) is used to instruct the terminal to ignore the newline.
+Some examples below contain multiple lines for readability. The forward slash
+(`\`) is used to instruct the terminal to ignore the newline.
 
 ## Setting variables
 
-You can set variables at the command line with `--variable` or in config files with `variable` (no dashes):
+You can set variables at the command line with `--variable` or in config files
+with `variable` (no dashes):
 
-### Example 1: Command line
+    curl --variable varName=content
 
-    curl \
-        --variable varName=content \
-
-### Example 2: Config file
+or in a config file:
 
     # Curl config file
 
@@ -34,16 +33,7 @@ You can set variables at the command line with `--variable` or in config files w
 
 You can assign the contents of a plain text file to a variable, too:
 
-### Example 1: Command line
-
-    curl \
-        --variable varName@filename \
-
-### Example 2: Config file
-
-    # Curl config file
-
-    variable varName@filename
+    curl --variable varName@filename
 
 ## Expand
 
@@ -58,13 +48,11 @@ Insert `{{` verbatim in the string by escaping it with a backslash:
 
 `\{{`.
 
-### Example
-
 In the example below, the variable `host` is set and then expanded:
 
     curl \ 
         --variable host=example \
-        --expand-url "https://{{host}}.com" \
+        --expand-url "https://{{host}}.com"
 
 For options specified without the `--expand-` prefix, variables are not
 expanded.
@@ -79,36 +67,31 @@ exit with an error if the given environment variable is not set. A user can
 also opt to set a default value if the environment variable does not exist,
 using `=content` or `@file` as described above.
 
-### Example 1: No default value set
-
-Assign the `%USER` environment variable to a curl variable and insert it into
-a URL. Because no default value is specified, this operation fails if the
-environment variable does not exist:
+As an example example, assign the `%USER` environment variable to a curl
+variable and insert it into a URL. Because no default value is specified, this
+operation fails if the environment variable does not exist:
 
     curl \ 
         --variable %USER \
-        --expand-url "https://example.com/api/{{USER}}/method" \
-
-### Example 2: Default value set    
+        --expand-url "https://example.com/api/{{USER}}/method"
 
 Instead, let's use `dummy` as a default value if `%USER` does not exist:
 
     curl \
         --variable %USER=dummy \
-        --expand-url "https://example.com/api/{{USER}}/method" \
+        --expand-url "https://example.com/api/{{USER}}/method"
 
 ## Expand `--variable`
 
-The `--variable` option itself can also be expanded, which allows you to assign variables to the contents of other variables.
-
-### Command line examples
+The `--variable` option itself can also be expanded, which allows you to
+assign variables to the contents of other variables.
 
     curl \
         --expand-variable var1={{var2}} \
         --expand-variable fullname=’Mrs {{first}} {{last}}’ \
-        --expand-variable source@{{filename}} \
+        --expand-variable source@{{filename}}
 
-### Config file examples
+Or done in a config file:
 
     # Curl config file
 
@@ -145,7 +128,9 @@ This is extra useful when reading data from files.
 
 ## Function: `json`
 
-Expands the variable as a valid JSON string. This makes it easier to insert valid JSON into into an argument (The quotes are not included in the resulting JSON).
+Expands the variable as a valid JSON string. This makes it easier to insert
+valid JSON into into an argument (The quotes are not included in the resulting
+JSON).
 
     --expand-json “\”full name\”: \”{{first:json}} {{last:json}}\””
 
@@ -156,7 +141,10 @@ To trim the variable first, apply both functions (in this order):
 
 ## Function: `url`
 
-Expands the variable URL encoded. Also known as *percent encoded*. This function ensures that all output characters are legal within a URL and the rest are encoded as `%HH` where `HH` is a two-digit hexadecimal number for the ascii value.
+Expands the variable URL encoded. Also known as *percent encoded*. This
+function ensures that all output characters are legal within a URL and the
+rest are encoded as `%HH` where `HH` is a two-digit hexadecimal number for the
+ascii value.
 
     --expand-data “varName={{varName:url}}”
 
@@ -166,7 +154,8 @@ To trim the variable first, apply both functions (in this order):
 
 ## Function: `b64`
 
-Expands the variable base64 encoded. Base64 is an encoding for binary data that only uses 64 specific characters.
+Expands the variable base64 encoded. Base64 is an encoding for binary data
+that only uses 64 specific characters.
 
     --expand-data “content={{value:b64}}”
     
@@ -174,9 +163,9 @@ To trim the variable first, apply both functions (in this order):
 
     --expand-data “content={{value:trim:b64}}”
 
-## Examples
-
-Example: get the contents of a file called `$HOME/.secret` into a variable called `fix`. Make sure that the content is trimmed and percent-encoded sent as POST data:
+Example: get the contents of a file called `$HOME/.secret` into a variable
+called `fix`. Make sure that the content is trimmed and percent-encoded sent
+as POST data:
 
     curl \
         --variable %HOME=/home/default \

--- a/libcurl/control/meter.md
+++ b/libcurl/control/meter.md
@@ -7,7 +7,7 @@ meter. Set it to `0L` to enable it.
 
 Return error to stop transfer
 
-## Example
+It can look something like this in code:
 
     #include <stdio.h>
     #include <curl/curl.h>

--- a/libcurl/control/ratelimit.md
+++ b/libcurl/control/ratelimit.md
@@ -7,7 +7,7 @@ below the given threshold over a period of multiple seconds.
 There are separate options for receiving (`CURLOPT_MAX_RECV_SPEED_LARGE`) and
 sending (`CURLOPT_MAX_SEND_SPEED_LARGE`).
 
-## Example
+Here is an example source code showing it in use:
 
     #include <stdio.h>
     #include <curl/curl.h>

--- a/libcurl/control/stopslow.md
+++ b/libcurl/control/stopslow.md
@@ -6,7 +6,7 @@ period without that being an error.
 Stop a transfer if below **N** bytes/sec during **M** seconds. Set **N** with
 `CURLOPT_LOW_SPEED_LIMIT` and set **M** with `CURLOPT_LOW_SPEED_TIME`.
 
-## Example
+Using these option in real code can look like this:
 
     #include <stdio.h>
     #include <curl/curl.h>

--- a/usingcurl/netrc.md
+++ b/usingcurl/netrc.md
@@ -43,9 +43,8 @@ Define a macro. This is **not supported by curl**. In order for the rest of
 the `.netrc` to still work fine, curl properly skips every definition done
 with `macdef` that it finds.
 
-## Example
-
-An example .netrc for the host example.com with a user named 'daniel', using the password 'qwerty' would look like:
+An example .netrc for the host example.com with a user named 'daniel', using
+the password 'qwerty' would look like:
 
     machine example.com
     login daniel

--- a/usingcurl/smtp.md
+++ b/usingcurl/smtp.md
@@ -31,7 +31,7 @@ A basic command to send an email:
     curl smtp://mail.example.com --mail-from myself@example.com --mail-rcpt \
     receiver@example.com --upload-file email.txt
 
-## Example email.txt
+An example `email.txt` could look like this:
 
     From: John Smith <john@example.com>
     To: Joe Smith <smith@example.com>

--- a/usingcurl/transfers/request-rate.md
+++ b/usingcurl/transfers/request-rate.md
@@ -30,10 +30,8 @@ separate retry delay logic is used and not this setting.
 
 If this option is used several times, the last one is used.
 
-## Examples
-
-Make curl download 100 images but doing it no faster than 2 transfers per
-second:
+For example, make curl download 100 images but doing it no faster than 2
+transfers per second:
 
     curl --rate 2/s -O https://example.com/[1-100].jpg
     


### PR DESCRIPTION
They are often just unnecessary