### PR TITLE
tweak table headers for PDF output

### DIFF
--- a/libcurl/getinfo.md
+++ b/libcurl/getinfo.md
@@ -34,7 +34,7 @@ If you want to extract the local port number that was used in that connection:
 ## Available information
 
 | Getinfo option                       | Type                  | Description                                                                   |
-|--------------------------------------|-----------------------|-------------------------------------------------------------------------------|
+|-------------------------------------------------|-------------------|---------------------------------------------|
 | `CURLINFO_ACTIVESOCKET`              | `curl_socket_t`       | The session's active socket                                                   |
 | `CURLINFO_APPCONNECT_TIME`           | `double`              | Time from start until SSL/SSH handshake completed                             |
 | `CURLINFO_APPCONNECT_TIME_T`         | `curl_off_t`          | Time from start until SSL/SSH handshake completed (in microseconds)           |

--- a/libcurl/options/all.md
+++ b/libcurl/options/all.md
@@ -3,7 +3,7 @@
 This is a table of available options for `curl_easy_setopt()`.
 
 | Option                               | Purpose                                                                |
-|--------------------------------------|------------------------------------------------------------------------|
+|--------------------------------------|------------------------------------------------|
 | `CURLOPT_ABSTRACT_UNIX_SOCKET`       | abstract Unix domain socket                                            |
 | `CURLOPT_ACCEPT_ENCODING`            | automatic decompression of HTTP downloads                              |
 | `CURLOPT_ACCEPTTIMEOUT_MS`           | timeout waiting for FTP server to connect back                         |

--- a/usingcurl/verbose/writeout.md
+++ b/usingcurl/verbose/writeout.md
@@ -58,7 +58,7 @@ user sees fit.
 Some of these variables are not available in really old curl versions.
 
 | Variable                  | Description                                                                                                                                                                                                                      |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | `certs`                   | Outputs the certificate chain from the most recent TLS handshake - with details. (Introduced in 7.88.0)                                                                                                                          |
 | `content_type`            | Content-Type of the requested document, if there was any.                                                                                                                                                                        |
 | `errormsg`                | Error message from the transfer. Empty if no error occurred. (Introduced in 7.75.0)                                                                                                                                              |
@@ -106,7 +106,7 @@ Some of these variables are not available in really old curl versions.
 In curl 8.1.0, variables to output only specific URL components were added. When the `url` or `url_effective` show more than you want.
 
 | Variable        | Description                                                                                                        |
-| --------------- | ------------------------------------------------------------------------------------------------------------------ |
+| --------------- | ---------------------------------------------------------------------- |
 | `url.scheme`    | The scheme part of the URL that was fetched.                                                                       |
 | `url.user`      | The user part of the URL that was fetched.                                                                         |
 | `url.password`  | The password part of the URL that was fetched.                                                                     |


### PR DESCRIPTION
Because of some peculiarity in pandoc it easily generates table columns that overlap when generating the PDF, which apparently can be tweaked by editing the length of the dashes on the top of the table.

But also: these tables possibly also show that they are not nice to do as tables when getting displayed in a page in a PDF as they have contents that make the columns very narrow. We should reconsider turning them into lists instead.

Fixes #418