### PR TITLE
http/post/browsersends.md: link the SSLKEYLOGFILE section

### DIFF
--- a/http/post/browsersends.md
+++ b/http/post/browsersends.md
@@ -12,5 +12,6 @@ A third option is, of course, to use a network capture tool such as Wireshark
 to check exactly what is sent over the wire. If you are working with HTTPS,
 you cannot see form submissions in clear text on the wire but instead you need
 to make sure you can have Wireshark extract your TLS private key from your
-browser. See the Wireshark documentation for details on doing that.
+browser. See the [SSLKEYLOGFILE section](../../usingcurl/tls/sslkeylogfile.md)
+for details on doing that.
 


### PR DESCRIPTION
... instead of refering to Wireshark docs.