### PR TITLE
Fix: forward slash -> backslash for '\'

### DIFF
--- a/cmdline/configfile.md
+++ b/cmdline/configfile.md
@@ -12,7 +12,7 @@ You can also use config files to assign data to variables and transform the
 data with functions, making them incredibly useful. This is discussed in the
 ["Variables"](https://everything.curl.dev/cmdline/variables) section.
 
-Some examples below contain multiple lines for readability. The forward slash
+Some examples below contain multiple lines for readability. The backslash
 (`\`) is used to instruct the terminal to ignore the newline.
 
 ## Specify the config file to use

--- a/cmdline/variables.md
+++ b/cmdline/variables.md
@@ -13,7 +13,7 @@ gets overwritten with new content. Variable names are case sensitive, can be
 up to 128 characters long and may consist of the characters a-z, A-Z, 0-9 and
 underscore.
 
-Some examples below contain multiple lines for readability. The forward slash
+Some examples below contain multiple lines for readability. The backslash
 (`\`) is used to instruct the terminal to ignore the newline.
 
 ## Setting variables


### PR DESCRIPTION
First of all, thank you for `curl` and the _everything curl_ guide.

In two locations where the backslash (`\`) was used, there was "forward slash" mentioned. These two occurrences have been fixed.