### PR TITLE
helpers/sharing.md: sync share options with CURLSHOPT_SHARE

### DIFF
--- a/helpers/sharing.md
+++ b/helpers/sharing.md
@@ -59,7 +59,7 @@ multiple concurrent threads.
 `CURL_LOCK_DATA_PSL` - this bit shares the Public Suffix List between handles.
 The list of public suffixes, aka top-level Internet domains, is used to help
 manage the security of cookies. Sharing the list prevents overhead from having
-to work with multiple copies of the list.
+to process multiple copies of the list.
 
 `CURL_LOCK_DATA_HSTS` - this bit shares the in-memory HSTS (HTTP Strict
 Transport Security) cache. HSTS is used by websites to indicate that HTTP


### PR DESCRIPTION
- Add CURL_LOCK_DATA_PSL and CURL_LOCK_DATA_HSTS.

- Explain that some option values are not supported multi-threaded: CURL_LOCK_DATA_COOKIE, CURL_LOCK_DATA_CONNECT, CURL_LOCK_DATA_HSTS.

Bug: https://github.com/curl/curl/issues/17774
Reported-by: afengsoft@users.noreply.github.com

Closes #xxxxx