### PR TITLE
Fix grammar in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ book. It features the book online in a web version.
 
 This book is also provided as a [PDF](https://daniel.haxx.se/everything-curl/everything-curl.pdf) and an [ePUB](https://daniel.haxx.se/everything-curl/everything-curl.epub).
 
-The book website is hosted by Fastly. The book contents is rendered by
+The book website is hosted by Fastly. The book content is rendered by
 [mdBook](https://github.com/rust-lang/mdBook) since March 18th, 2024.
 
 ## Content


### PR DESCRIPTION
Fix the grammar in one section of `README.md`, that changes "book contents is rendered" to "book content is rendered"