### PR TITLE
Fix curlrc dot typo for $XDG_CONFIG_HOME

### DIFF
--- a/cmdline/configfile.md
+++ b/cmdline/configfile.md
@@ -111,7 +111,7 @@ order:
 
 1) `$CURL_HOME/.curlrc`
 
-2) `$XDG_CONFIG_HOME/.curlrc` (Added in 7.73.0)
+2) `$XDG_CONFIG_HOME/curlrc` (Added in 7.73.0)
 
 3) `$HOME/.curlrc`
 


### PR DESCRIPTION
Should be a follow-up to https://github.com/curl/curl/pull/14600.

This one dot cost me an hour of sanity 😆