### PR TITLE
remove all references to 'Secure Transport'

### DIFF
--- a/build/autotools.md
+++ b/build/autotools.md
@@ -84,7 +84,6 @@ automatically check for OpenSSL, but modern versions do not.
  - OpenSSL: `--with-openssl`
  - Rustls: `--with-rustls` (point to the rustls-ffi install path)
  - Schannel: `--with-schannel`
- - Secure Transport: `--with-secure-transport`
  - wolfSSL: `--with-wolfssl`
 
 If you do not specify which TLS library to use, the configure script fails. If

--- a/build/tls.md
+++ b/build/tls.md
@@ -16,7 +16,6 @@ curl is written to work with a large number of TLS libraries:
  - OpenSSL
  - rustls
  - Schannel (native Windows)
- - Secure Transport (native macOS)
  - WolfSSL
 
 When you build curl and libcurl to use one of these libraries, it is important
@@ -69,16 +68,6 @@ configure detects mbedTLS in its default path by default. You can optionally
 point configure to a custom install path prefix where it can find mbedTLS:
 
     ./configure --with-mbedtls=/home/user/installed/mbedtls
-
-### Secure Transport
-
-    ./configure --with-secure-transport
-
-configure detects Secure Transport in its default path by default. You can
-optionally point configure to a custom install path prefix where it can find
-Secure Transport:
-
-    ./configure --with-secure-transport=/home/user/installed/darwinssl
 
 ### Schannel
 

--- a/source/layout.md
+++ b/source/layout.md
@@ -62,7 +62,6 @@ users.
 - OpenSSL
 - rustls: a TLS library written in rust
 - Schannel: the native TLS library on Windows.
-- Secure Transport: the native TLS library on macOS
 - wolfSSL
 
 ## src

--- a/usingcurl/tls/verify.md
+++ b/usingcurl/tls/verify.md
@@ -28,23 +28,20 @@ Operating systems like Windows and macOS tend to have their own CA stores.
 If you run curl with Schannel on Windows, curl uses Windows' own CA store by
 default.
 
-If you run curl with Secure Transport on macOS, curl uses macOS' own CA store
-by default.
-
-If you use curl with any other TLS backend than Schannel or Secure Transport,
-it uses a CA store provided in a separate file or directory, independently of
-the native CA store. However, for some of them you can still ask curl to
-instead prefer the native CA store using the `--ca-native` command line
-option. This option is supported with OpenSSL (and forks), wolfSSL and GnuTLS.
+If you use curl with any other TLS backend than Schannel, it uses a CA store
+provided in a separate file or directory, independently of the native CA
+store. However, for some of them you can still ask curl to instead prefer the
+native CA store using the `--ca-native` command line option. This option is
+supported with OpenSSL (and forks), wolfSSL and GnuTLS.
 
 For HTTPS proxies, the corresponding option is called `--proxy-ca-native`.
 
 ## CA store in file(s)
 
 If curl is not built to use a TLS library that is native to your platform
-(like Schannel or Secure Transport), it has to either have been built to know
-where the local CA store is, or users need to provide a path to the CA store
-when curl is invoked.
+(like Schannel), it has to either have been built to know where the local CA
+store is, or users need to provide a path to the CA store when curl is
+invoked.
 
 You can point out a specific CA bundle to use in the TLS handshake with the
 `--cacert` command line option. That bundle needs to be in PEM format. You can


### PR DESCRIPTION
This backend was removed a while back